### PR TITLE
Added basic config for FOSRestApi to app/config/config.yml

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -127,3 +127,8 @@ sonata_block:
         sonata.block.service.action:
         sonata.block.service.rss:
         sonata.block.service.tableinput:
+
+# FOS Rest API
+fos_rest:
+    routing_loader:
+        default_format: json


### PR DESCRIPTION
Maybe we should include a small configuration for FOS Rest API as default, so it can work "out of the box" as soon as you create your controller.