### PR TITLE
SonataAdminBundle dev-master stable version

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -131,6 +131,7 @@ sonata_block:
         sonata.block.service.action:
         sonata.block.service.rss:
         sonata.block.service.tableinput:
+        sonata.admin.block.search_result:
 
 # FOS Rest API
 fos_rest:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/doctrine-fixtures-bundle": "~2.0",
         "sensio/generator-bundle": "~2.3",
         "kriswallsmith/assetic": "1.2.*",
-        "sonata-project/admin-bundle": "dev-master#2ec433d",
+        "sonata-project/admin-bundle": "dev-master#54d4e2a",
         "sonata-project/doctrine-extensions": "1.*",
         "sonata-project/easy-extends-bundle" : "2.1.*",
         "sonata-project/cache-bundle": "~2.2",


### PR DESCRIPTION
Set this version of SonataAdminBundle in composer.json to fix the InlineConstraint Validation error and keep compatibility with the other bundles.

Enable SonataAdmin search result block by default.
